### PR TITLE
Update changelog for 2023 July - December

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1306,13 +1306,13 @@ Jump to month: [January](#2023-January) • [February](#2023-February) • [Ma
 
 - **Global**: Crawl each admin repository to add concordances to "official" government sources, call out which sources are designated as "official" with a new `wof:concordances_official` property. Commonly available on coarse admin placetype features and limited coverage for `locality` and `localadmin` features. Issue [#2164](https://github.com/whosonfirst-data/whosonfirst-data/issues/2164))
 - **Global**: Geocode.Earth's Who's On First distributions now support the new official concordance keys and values, and removed the name contraint. (Issue [pelias/wof#49](https://github.com/pelias/wof/pull/49) and [pelias/wof#52](https://github.com/pelias/wof/pull/52))
-- **Spain**: Using data from the Centro de Descargas, update administrative records in Spain including Ceuta and Melilla. Issue [#706](https://github.com/whosonfirst-data/whosonfirst-data/issues/706))
+- **Spain**: Using data from Organismo Autonomo Centro Nacional de Information Geografica (CNIG), update administrative records in Spain – including Ceuta and Melilla. Issue [#706](https://github.com/whosonfirst-data/whosonfirst-data/issues/706))
 - **United Kingdom**: Wrangle UK records, moving them from the `admin-xy` repository to the `admin-gb` repository. Issue [#2024](https://github.com/whosonfirst-data/whosonfirst-data/issues/2024))
 - **Various**: 21 [edits](https://github.com/pulls?q=is%3Apr+user%3Awhosonfirst-data+archived%3Afalse+merged%3A2023-10-01..2023-10-31+is%3Aclosed+) made directly to the individual country repos as PRs...
 
 ### 2023 November
 
-- **United Kingdom**: Using United Kingdom and Northern Ireland Ordnance Survey data, update records and geometries at various placetypes. This includes updates to `localadmin`, `county`, `macrocounty`, `region`, `macroregion`, and `country` records. Additional work is contemplated at the `locality` level but not included here. Pull request [#92](https://github.com/whosonfirst-data/whosonfirst-data-admin-gb/pull/92))
+- **United Kingdom**: Using United Kingdom and Northern Ireland Ordnance Survey data, update records and geometries at various placetypes, including `localadmin`, `county`, `macrocounty`, `region`, `macroregion`, and `country` records. Additional work is contemplated at the `locality` level but not included here. Pull request [#92](https://github.com/whosonfirst-data/whosonfirst-data-admin-gb/pull/92) as a downpayment on issue [#1871](https://github.com/whosonfirst-data/whosonfirst-data/issues/1871)
 - **Various**: A quiet month
 
 ### 2023 Decemmber

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1292,10 +1292,27 @@ Jump to month: [January](#2023-January) • [February](#2023-February) • [Ma
 ### 2023 August
 
 - **Global**: Rerun Wikidata name localization import on per-country repos. This yielded new name properties across 269,088 records. (Issue [#1656](https://github.com/whosonfirst-data/whosonfirst-data/issues/2151))
+- **Global**: The `modified` fields in Geocode.Earth's Who's On First distributions have been updated. (Issue [#1737](https://github.com/whosonfirst-data/whosonfirst-data/issues/1737))
 - **Various**: 7 [edits](https://github.com/pulls?q=is%3Apr+user%3Awhosonfirst-data+archived%3Afalse+merged%3A2023-08-01..2023-08-31+is%3Aclosed+) made directly to the individual country repos as PRs...
 
 ### 2023 September
 
+- **Global**: Substantially increase name and label property coverage across various placetypes. (Issue [#2154](https://github.com/whosonfirst-data/whosonfirst-data/issues/2154))
+- **Global**: Geocode.Earth's Who's On First distributions now support the placelocal property. (Issue [#2160](https://github.com/whosonfirst-data/whosonfirst-data/issues/2160))
 - **Various**: 5 [edits](https://github.com/pulls?q=is%3Apr+user%3Awhosonfirst-data+archived%3Afalse+merged%3A2023-09-01..2023-09-31+is%3Aclosed+) made directly to the individual country repos as PRs...
+
+### 2023 October
+
+- **Global**: Crawl each admin repository to add concordances to "official" government sources, call out which sources are designated as "official" with a new `wof:concordances_official` property. Issue [#2164](https://github.com/whosonfirst-data/whosonfirst-data/issues/2164))
+- **Spain**: Using data from the Centro de Descargas, update administrative records in Spain including Ceuta and Melilla. Issue [#706](https://github.com/whosonfirst-data/whosonfirst-data/issues/706))
+- **United Kingdom**: Wrangle UK records, moving them from the `admin-xy` repository to the `admin-gb` repository. Issue [#2024](https://github.com/whosonfirst-data/whosonfirst-data/issues/2024))
+- **Various**: 21 [edits](https://github.com/pulls?q=is%3Apr+user%3Awhosonfirst-data+archived%3Afalse+merged%3A2023-09-01..2023-09-31+is%3Aclosed+) made directly to the individual country repos as PRs...
+
+### 2023 November
+
+- **United Kingdom**: Using Ordnance Survey data, update records and geometries at various placetypes. This includes updates to locality, localadmin, county, macrocounty, region, macroregion, and country records. Pull request [#92](https://github.com/whosonfirst-data/whosonfirst-data-admin-gb/pull/92))
+
+### 2023 Decemmber
+- **Various**: 15 [edits](https://github.com/pulls?q=is%3Apr+user%3Awhosonfirst-data+archived%3Afalse+merged%3A2023-09-01..2023-09-31+is%3Aclosed+) made directly to the individual country repos as PRs...
 
 _NOTE: This document was created 2019 November._

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1293,7 +1293,7 @@ Jump to month: [January](#2023-January) • [February](#2023-February) • [Ma
 
 - **Global**: Rerun Wikidata name localization import on per-country repos. This yielded new name properties across 269,088 records. (Issue [#1656](https://github.com/whosonfirst-data/whosonfirst-data/issues/2151))
 - **Global**: Ensure placetype_alt listed features are exported at both levels in Geocode.Earth's Who's On First shapefile distributions. (Issue [pelias/wof#43](https://github.com/pelias/wof/pull/43))
-- **Global**: The `modified` fields in Geocode.Earth's Who's On First distributions have been updated (from `date`) to match SPR conventions. (Issue [#1737](https://github.com/whosonfirst-data/whosonfirst-data/issues/1737))
+- **Global**: The `modified` fields in Geocode.Earth's Who's On First distributions have been updated (from `date`) to match SPR conventions. (Issue [#2160](https://github.com/whosonfirst-data/whosonfirst-data/issues/2160))
 - **Various**: 2 [edits](https://github.com/pulls?q=is%3Apr+user%3Awhosonfirst-data+archived%3Afalse+merged%3A2023-08-01..2023-08-31+is%3Aclosed+) made directly to the individual country repos as PRs...
 
 ### 2023 September

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1282,4 +1282,20 @@ Jump to month: [January](#2023-January) • [February](#2023-February) • [Ma
 - **Blog post**: [State of the Gazetteer in 2023](https://whosonfirst.org/blog/2023/06/07/state-of-the-gazetteer/) - Since we launched in 2015, the Who’s On First places gazetteer project has grown in coverage, complexity, and supported applications. In this this post I will summarize Who’s On First’s key advantages, offer a comparative analysis of WOF and other open gazetteers, quantify our global coverage by placetype, offer score cards by country, dive into name localization, look at internationalization through the lens of disputed territories, and quantify geometry types and sources of those polygon and points, hold hands with and thank our sources, and invite collaboration.
 - **Blog post**: [Introducing Karmashapes](https://whosonfirst.org/blog/2023/06/19/introducting-karmashapes/) - Thanks to the Karmashapes initiative, Who’s On First now provides the best open data for towns and villages in India.
 
+### 2023 July
+
+- **United Kingdom**: Update postalcode records, syncing them with the newest ONS dataset (Pull request [gb/#11](https://github.com/whosonfirst-data/whosonfirst-data-postalcode-gb/pull/11))
+- **United Kingdom**: Migrated admin records from the `whosonfirst-data-admin-xy` repo to the appropriate `admin-gb` repo (Pull request [xy/#33](https://github.com/whosonfirst-data/whosonfirst-data-admin-xy/pull/33))
+- **Norway**: Fixed bogus superseding in the Bergen locality record `whosonfirst-data-admin-xy` repo to the appropriate `admin-gb` repo (Pull request [gb/#41](https://github.com/whosonfirst-data/whosonfirst-data-admin-no/pull/41))
+- **Various**: 7 [edits](https://github.com/pulls?q=is%3Apr+user%3Awhosonfirst-data+archived%3Afalse+merged%3A2023-07-01..2023-07-31+is%3Aclosed+) made directly to the individual country repos as PRs...
+
+### 2023 August
+
+- **Global**: Rerun Wikidata name localization import on per-country repos. This yielded new name properties across 269,088 records. (Issue [#1656](https://github.com/whosonfirst-data/whosonfirst-data/issues/2151))
+- **Various**: 7 [edits](https://github.com/pulls?q=is%3Apr+user%3Awhosonfirst-data+archived%3Afalse+merged%3A2023-08-01..2023-08-31+is%3Aclosed+) made directly to the individual country repos as PRs...
+
+### 2023 September
+
+- **Various**: 5 [edits](https://github.com/pulls?q=is%3Apr+user%3Awhosonfirst-data+archived%3Afalse+merged%3A2023-09-01..2023-09-31+is%3Aclosed+) made directly to the individual country repos as PRs...
+
 _NOTE: This document was created 2019 November._

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1292,7 +1292,8 @@ Jump to month: [January](#2023-January) • [February](#2023-February) • [Ma
 ### 2023 August
 
 - **Global**: Rerun Wikidata name localization import on per-country repos. This yielded new name properties across 269,088 records. (Issue [#1656](https://github.com/whosonfirst-data/whosonfirst-data/issues/2151))
-- **Global**: The `modified` fields in Geocode.Earth's Who's On First distributions have been updated. (Issue [#1737](https://github.com/whosonfirst-data/whosonfirst-data/issues/1737))
+- **Global**: Ensure placetype_alt listed features are exported at both levels in Geocode.Earth's Who's On First shapefile distributions. (Issue [pelias/wof#43](https://github.com/pelias/wof/pull/43))
+- **Global**: The `modified` fields in Geocode.Earth's Who's On First distributions have been updated (from `date`) to match SPR conventions. (Issue [#1737](https://github.com/whosonfirst-data/whosonfirst-data/issues/1737))
 - **Various**: 7 [edits](https://github.com/pulls?q=is%3Apr+user%3Awhosonfirst-data+archived%3Afalse+merged%3A2023-08-01..2023-08-31+is%3Aclosed+) made directly to the individual country repos as PRs...
 
 ### 2023 September
@@ -1303,16 +1304,18 @@ Jump to month: [January](#2023-January) • [February](#2023-February) • [Ma
 
 ### 2023 October
 
-- **Global**: Crawl each admin repository to add concordances to "official" government sources, call out which sources are designated as "official" with a new `wof:concordances_official` property. Issue [#2164](https://github.com/whosonfirst-data/whosonfirst-data/issues/2164))
+- **Global**: Crawl each admin repository to add concordances to "official" government sources, call out which sources are designated as "official" with a new `wof:concordances_official` property. Commonly available on coarse admin placetype features and limited coverage for `locality` and `localadmin` features. Issue [#2164](https://github.com/whosonfirst-data/whosonfirst-data/issues/2164))
+- **Global**: Geocode.Earth's Who's On First distributions now support the new official concordance keys and values, and removed the name contraint. (Issue [pelias/wof#49](https://github.com/pelias/wof/pull/49) and [pelias/wof#52](https://github.com/pelias/wof/pull/52))
 - **Spain**: Using data from the Centro de Descargas, update administrative records in Spain including Ceuta and Melilla. Issue [#706](https://github.com/whosonfirst-data/whosonfirst-data/issues/706))
 - **United Kingdom**: Wrangle UK records, moving them from the `admin-xy` repository to the `admin-gb` repository. Issue [#2024](https://github.com/whosonfirst-data/whosonfirst-data/issues/2024))
 - **Various**: 21 [edits](https://github.com/pulls?q=is%3Apr+user%3Awhosonfirst-data+archived%3Afalse+merged%3A2023-09-01..2023-09-31+is%3Aclosed+) made directly to the individual country repos as PRs...
 
 ### 2023 November
 
-- **United Kingdom**: Using Ordnance Survey data, update records and geometries at various placetypes. This includes updates to locality, localadmin, county, macrocounty, region, macroregion, and country records. Pull request [#92](https://github.com/whosonfirst-data/whosonfirst-data-admin-gb/pull/92))
+- **United Kingdom**: Using United Kingdom and Northern Ireland Ordnance Survey data, update records and geometries at various placetypes. This includes updates to `localadmin`, `county`, `macrocounty`, `region`, `macroregion`, and `country` records. Additional work is contemplated at the `locality` level but not included here. Pull request [#92](https://github.com/whosonfirst-data/whosonfirst-data-admin-gb/pull/92))
 
 ### 2023 Decemmber
+
 - **Various**: 15 [edits](https://github.com/pulls?q=is%3Apr+user%3Awhosonfirst-data+archived%3Afalse+merged%3A2023-09-01..2023-09-31+is%3Aclosed+) made directly to the individual country repos as PRs...
 
 _NOTE: This document was created 2019 November._

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1294,7 +1294,7 @@ Jump to month: [January](#2023-January) • [February](#2023-February) • [Ma
 - **Global**: Rerun Wikidata name localization import on per-country repos. This yielded new name properties across 269,088 records. (Issue [#1656](https://github.com/whosonfirst-data/whosonfirst-data/issues/2151))
 - **Global**: Ensure placetype_alt listed features are exported at both levels in Geocode.Earth's Who's On First shapefile distributions. (Issue [pelias/wof#43](https://github.com/pelias/wof/pull/43))
 - **Global**: The `modified` fields in Geocode.Earth's Who's On First distributions have been updated (from `date`) to match SPR conventions. (Issue [#1737](https://github.com/whosonfirst-data/whosonfirst-data/issues/1737))
-- **Various**: 7 [edits](https://github.com/pulls?q=is%3Apr+user%3Awhosonfirst-data+archived%3Afalse+merged%3A2023-08-01..2023-08-31+is%3Aclosed+) made directly to the individual country repos as PRs...
+- **Various**: 2 [edits](https://github.com/pulls?q=is%3Apr+user%3Awhosonfirst-data+archived%3Afalse+merged%3A2023-08-01..2023-08-31+is%3Aclosed+) made directly to the individual country repos as PRs...
 
 ### 2023 September
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1286,7 +1286,7 @@ Jump to month: [January](#2023-January) • [February](#2023-February) • [Ma
 
 - **United Kingdom**: Update postalcode records, syncing them with the newest ONS dataset (Pull request [gb/#11](https://github.com/whosonfirst-data/whosonfirst-data-postalcode-gb/pull/11))
 - **United Kingdom**: Migrated admin records from the `whosonfirst-data-admin-xy` repo to the appropriate `admin-gb` repo (Pull request [xy/#33](https://github.com/whosonfirst-data/whosonfirst-data-admin-xy/pull/33))
-- **Norway**: Fixed bogus superseding in the Bergen locality record `whosonfirst-data-admin-xy` repo to the appropriate `admin-gb` repo (Pull request [gb/#41](https://github.com/whosonfirst-data/whosonfirst-data-admin-no/pull/41))
+- **Norway**: Fixed bogus superseding in the Bergen locality record `whosonfirst-data-admin-xy` repo to the appropriate `admin-gb` repo (Issue [#2148](https://github.com/whosonfirst-data/whosonfirst-data/issues/2148))
 - **Various**: 7 [edits](https://github.com/pulls?q=is%3Apr+user%3Awhosonfirst-data+archived%3Afalse+merged%3A2023-07-01..2023-07-31+is%3Aclosed+) made directly to the individual country repos as PRs...
 
 ### 2023 August

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1304,7 +1304,7 @@ Jump to month: [January](#2023-January) • [February](#2023-February) • [Ma
 
 ### 2023 October
 
-- **Global**: Crawl each admin repository to add concordances to "official" government sources, call out which sources are designated as "official" with a new `wof:concordances_official` property. Commonly available on coarse admin placetype features and limited coverage for `locality` and `localadmin` features. Issue [#2164](https://github.com/whosonfirst-data/whosonfirst-data/issues/2164))
+- **Global**: Crawl each admin repository to add additional concordance keys and values for "official" government sources, and additionally indicate which of the many concordances should be considered as "official" with a new `wof:concordances_official` property. Commonly available on coarse admin placetype features and limited coverage for `locality` and `localadmin` features. Issue [#2164](https://github.com/whosonfirst-data/whosonfirst-data/issues/2164))
 - **Global**: Geocode.Earth's Who's On First distributions now support the new official concordance keys and values, and removed the name contraint. (Issue [pelias/wof#49](https://github.com/pelias/wof/pull/49) and [pelias/wof#52](https://github.com/pelias/wof/pull/52))
 - **Spain**: Using data from Organismo Autonomo Centro Nacional de Information Geografica (CNIG), update administrative records in Spain – including Ceuta and Melilla. Issue [#706](https://github.com/whosonfirst-data/whosonfirst-data/issues/706))
 - **United Kingdom**: Wrangle UK records, moving them from the `admin-xy` repository to the `admin-gb` repository. Issue [#2024](https://github.com/whosonfirst-data/whosonfirst-data/issues/2024))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1287,20 +1287,20 @@ Jump to month: [January](#2023-January) • [February](#2023-February) • [Ma
 - **United Kingdom**: Update postalcode records, syncing them with the newest ONS dataset (Pull request [gb/#11](https://github.com/whosonfirst-data/whosonfirst-data-postalcode-gb/pull/11))
 - **United Kingdom**: Migrated admin records from the `whosonfirst-data-admin-xy` repo to the appropriate `admin-gb` repo (Pull request [xy/#33](https://github.com/whosonfirst-data/whosonfirst-data-admin-xy/pull/33))
 - **Norway**: Fixed bogus superseding in the Bergen locality record `whosonfirst-data-admin-xy` repo to the appropriate `admin-gb` repo (Issue [#2148](https://github.com/whosonfirst-data/whosonfirst-data/issues/2148))
-- **Various**: 7 [edits](https://github.com/pulls?q=is%3Apr+user%3Awhosonfirst-data+archived%3Afalse+merged%3A2023-07-01..2023-07-31+is%3Aclosed+WOF+Editor+) made directly to the individual country repos as PRs...
+- **Various**: 4 [edits](https://github.com/pulls?q=is%3Apr+user%3Awhosonfirst-data+archived%3Afalse+merged%3A2023-07-01..2023-07-31+is%3Aclosed+WOF+Editor+) made directly to the individual country repos as PRs...
 
 ### 2023 August
 
 - **Global**: Rerun Wikidata name localization import on per-country repos. This yielded new name properties across 269,088 records. (Issue [#1656](https://github.com/whosonfirst-data/whosonfirst-data/issues/2151))
 - **Global**: Ensure placetype_alt listed features are exported at both levels in Geocode.Earth's Who's On First shapefile distributions. (Issue [pelias/wof#43](https://github.com/pelias/wof/pull/43))
 - **Global**: The `modified` fields in Geocode.Earth's Who's On First distributions have been updated (from `date`) to match SPR conventions. (Issue [#2160](https://github.com/whosonfirst-data/whosonfirst-data/issues/2160))
-- **Various**: 2 [edits](https://github.com/pulls?q=is%3Apr+user%3Awhosonfirst-data+archived%3Afalse+merged%3A2023-08-01..2023-08-31+is%3Aclosed+WOF+Editor+) made directly to the individual country repos as PRs...
+- **Various**: 7 [edits](https://github.com/pulls?q=is%3Apr+user%3Awhosonfirst-data+archived%3Afalse+merged%3A2023-08-01..2023-08-31+is%3Aclosed+WOF+Editor+) made directly to the individual country repos as PRs...
 
 ### 2023 September
 
 - **Global**: Substantially increase name and label property coverage across various placetypes. (Issue [#2154](https://github.com/whosonfirst-data/whosonfirst-data/issues/2154))
 - **Global**: Add support for new placelocal property in Geocode.Earth's Who's On First shapefile distributions. (Issue [#2153](https://github.com/whosonfirst-data/whosonfirst-data/issues/2153))
-- **Various**: 5 [edits](https://github.com/pulls?q=is%3Apr+user%3Awhosonfirst-data+archived%3Afalse+merged%3A2023-09-01..2023-09-30+is%3Aclosed+WOF+Editor+) made directly to the individual country repos as PRs...
+- **Various**: 4 [edits](https://github.com/pulls?q=is%3Apr+user%3Awhosonfirst-data+archived%3Afalse+merged%3A2023-09-01..2023-09-30+is%3Aclosed+WOF+Editor+) made directly to the individual country repos as PRs...
 
 ### 2023 October
 
@@ -1308,7 +1308,7 @@ Jump to month: [January](#2023-January) • [February](#2023-February) • [Ma
 - **Global**: Geocode.Earth's Who's On First distributions now support the new official concordance keys and values, and removed the name contraint. (Issue [pelias/wof#49](https://github.com/pelias/wof/pull/49) and [pelias/wof#52](https://github.com/pelias/wof/pull/52))
 - **Spain**: Using data from Organismo Autonomo Centro Nacional de Information Geografica (CNIG), update administrative records in Spain – including Ceuta and Melilla. Issue [#706](https://github.com/whosonfirst-data/whosonfirst-data/issues/706))
 - **United Kingdom**: Wrangle UK records, moving them from the `admin-xy` repository to the `admin-gb` repository. Issue [#2024](https://github.com/whosonfirst-data/whosonfirst-data/issues/2024))
-- **Various**: 21 [edits](https://github.com/pulls?q=is%3Apr+user%3Awhosonfirst-data+archived%3Afalse+merged%3A2023-10-01..2023-10-31+is%3Aclosed+WOF+Editor+) made directly to the individual country repos as PRs...
+- **Various**: 22 [edits](https://github.com/pulls?q=is%3Apr+user%3Awhosonfirst-data+archived%3Afalse+merged%3A2023-10-01..2023-10-31+is%3Aclosed+WOF+Editor+) made directly to the individual country repos as PRs...
 
 ### 2023 November
 
@@ -1317,6 +1317,6 @@ Jump to month: [January](#2023-January) • [February](#2023-February) • [Ma
 
 ### 2023 Decemmber
 
-- **Various**: 15 [edits](https://github.com/pulls?q=is%3Apr+user%3Awhosonfirst-data+archived%3Afalse+merged%3A2023-12-01..2023-12-31+is%3Aclosed+WOF+Editor+) made directly to the individual country repos as PRs...
+- **Various**: 16 [edits](https://github.com/pulls?q=is%3Apr+user%3Awhosonfirst-data+archived%3Afalse+merged%3A2023-12-01..2023-12-31+is%3Aclosed+WOF+Editor+) made directly to the individual country repos as PRs...
 
 _NOTE: This document was created 2019 November._

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1299,7 +1299,7 @@ Jump to month: [January](#2023-January) • [February](#2023-February) • [Ma
 ### 2023 September
 
 - **Global**: Substantially increase name and label property coverage across various placetypes. (Issue [#2154](https://github.com/whosonfirst-data/whosonfirst-data/issues/2154))
-- **Global**: Geocode.Earth's Who's On First distributions now support the placelocal property. (Issue [#2160](https://github.com/whosonfirst-data/whosonfirst-data/issues/2160))
+- **Global**: Add support for new placelocal property in Geocode.Earth's Who's On First shapefile distributions. (Issue [#2153](https://github.com/whosonfirst-data/whosonfirst-data/issues/2153))
 - **Various**: 5 [edits](https://github.com/pulls?q=is%3Apr+user%3Awhosonfirst-data+archived%3Afalse+merged%3A2023-09-01..2023-09-31+is%3Aclosed+) made directly to the individual country repos as PRs...
 
 ### 2023 October

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1287,20 +1287,20 @@ Jump to month: [January](#2023-January) • [February](#2023-February) • [Ma
 - **United Kingdom**: Update postalcode records, syncing them with the newest ONS dataset (Pull request [gb/#11](https://github.com/whosonfirst-data/whosonfirst-data-postalcode-gb/pull/11))
 - **United Kingdom**: Migrated admin records from the `whosonfirst-data-admin-xy` repo to the appropriate `admin-gb` repo (Pull request [xy/#33](https://github.com/whosonfirst-data/whosonfirst-data-admin-xy/pull/33))
 - **Norway**: Fixed bogus superseding in the Bergen locality record `whosonfirst-data-admin-xy` repo to the appropriate `admin-gb` repo (Issue [#2148](https://github.com/whosonfirst-data/whosonfirst-data/issues/2148))
-- **Various**: 7 [edits](https://github.com/pulls?q=is%3Apr+user%3Awhosonfirst-data+archived%3Afalse+merged%3A2023-07-01..2023-07-31+is%3Aclosed+) made directly to the individual country repos as PRs...
+- **Various**: 7 [edits](https://github.com/pulls?q=is%3Apr+user%3Awhosonfirst-data+archived%3Afalse+merged%3A2023-07-01..2023-07-31+is%3Aclosed+WOF+Editor+) made directly to the individual country repos as PRs...
 
 ### 2023 August
 
 - **Global**: Rerun Wikidata name localization import on per-country repos. This yielded new name properties across 269,088 records. (Issue [#1656](https://github.com/whosonfirst-data/whosonfirst-data/issues/2151))
 - **Global**: Ensure placetype_alt listed features are exported at both levels in Geocode.Earth's Who's On First shapefile distributions. (Issue [pelias/wof#43](https://github.com/pelias/wof/pull/43))
 - **Global**: The `modified` fields in Geocode.Earth's Who's On First distributions have been updated (from `date`) to match SPR conventions. (Issue [#2160](https://github.com/whosonfirst-data/whosonfirst-data/issues/2160))
-- **Various**: 2 [edits](https://github.com/pulls?q=is%3Apr+user%3Awhosonfirst-data+archived%3Afalse+merged%3A2023-08-01..2023-08-31+is%3Aclosed+) made directly to the individual country repos as PRs...
+- **Various**: 2 [edits](https://github.com/pulls?q=is%3Apr+user%3Awhosonfirst-data+archived%3Afalse+merged%3A2023-08-01..2023-08-31+is%3Aclosed+WOF+Editor+) made directly to the individual country repos as PRs...
 
 ### 2023 September
 
 - **Global**: Substantially increase name and label property coverage across various placetypes. (Issue [#2154](https://github.com/whosonfirst-data/whosonfirst-data/issues/2154))
 - **Global**: Add support for new placelocal property in Geocode.Earth's Who's On First shapefile distributions. (Issue [#2153](https://github.com/whosonfirst-data/whosonfirst-data/issues/2153))
-- **Various**: 5 [edits](https://github.com/pulls?q=is%3Apr+user%3Awhosonfirst-data+archived%3Afalse+merged%3A2023-09-01..2023-09-30+is%3Aclosed+) made directly to the individual country repos as PRs...
+- **Various**: 5 [edits](https://github.com/pulls?q=is%3Apr+user%3Awhosonfirst-data+archived%3Afalse+merged%3A2023-09-01..2023-09-30+is%3Aclosed+WOF+Editor+) made directly to the individual country repos as PRs...
 
 ### 2023 October
 
@@ -1308,7 +1308,7 @@ Jump to month: [January](#2023-January) • [February](#2023-February) • [Ma
 - **Global**: Geocode.Earth's Who's On First distributions now support the new official concordance keys and values, and removed the name contraint. (Issue [pelias/wof#49](https://github.com/pelias/wof/pull/49) and [pelias/wof#52](https://github.com/pelias/wof/pull/52))
 - **Spain**: Using data from Organismo Autonomo Centro Nacional de Information Geografica (CNIG), update administrative records in Spain – including Ceuta and Melilla. Issue [#706](https://github.com/whosonfirst-data/whosonfirst-data/issues/706))
 - **United Kingdom**: Wrangle UK records, moving them from the `admin-xy` repository to the `admin-gb` repository. Issue [#2024](https://github.com/whosonfirst-data/whosonfirst-data/issues/2024))
-- **Various**: 21 [edits](https://github.com/pulls?q=is%3Apr+user%3Awhosonfirst-data+archived%3Afalse+merged%3A2023-10-01..2023-10-31+is%3Aclosed+) made directly to the individual country repos as PRs...
+- **Various**: 21 [edits](https://github.com/pulls?q=is%3Apr+user%3Awhosonfirst-data+archived%3Afalse+merged%3A2023-10-01..2023-10-31+is%3Aclosed+WOF+Editor+) made directly to the individual country repos as PRs...
 
 ### 2023 November
 
@@ -1317,6 +1317,6 @@ Jump to month: [January](#2023-January) • [February](#2023-February) • [Ma
 
 ### 2023 Decemmber
 
-- **Various**: 15 [edits](https://github.com/pulls?q=is%3Apr+user%3Awhosonfirst-data+archived%3Afalse+merged%3A2023-12-01..2023-12-31+is%3Aclosed+) made directly to the individual country repos as PRs...
+- **Various**: 15 [edits](https://github.com/pulls?q=is%3Apr+user%3Awhosonfirst-data+archived%3Afalse+merged%3A2023-12-01..2023-12-31+is%3Aclosed+WOF+Editor+) made directly to the individual country repos as PRs...
 
 _NOTE: This document was created 2019 November._

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1300,7 +1300,7 @@ Jump to month: [January](#2023-January) • [February](#2023-February) • [Ma
 
 - **Global**: Substantially increase name and label property coverage across various placetypes. (Issue [#2154](https://github.com/whosonfirst-data/whosonfirst-data/issues/2154))
 - **Global**: Add support for new placelocal property in Geocode.Earth's Who's On First shapefile distributions. (Issue [#2153](https://github.com/whosonfirst-data/whosonfirst-data/issues/2153))
-- **Various**: 5 [edits](https://github.com/pulls?q=is%3Apr+user%3Awhosonfirst-data+archived%3Afalse+merged%3A2023-09-01..2023-09-31+is%3Aclosed+) made directly to the individual country repos as PRs...
+- **Various**: 5 [edits](https://github.com/pulls?q=is%3Apr+user%3Awhosonfirst-data+archived%3Afalse+merged%3A2023-09-01..2023-09-30+is%3Aclosed+) made directly to the individual country repos as PRs...
 
 ### 2023 October
 
@@ -1308,14 +1308,15 @@ Jump to month: [January](#2023-January) • [February](#2023-February) • [Ma
 - **Global**: Geocode.Earth's Who's On First distributions now support the new official concordance keys and values, and removed the name contraint. (Issue [pelias/wof#49](https://github.com/pelias/wof/pull/49) and [pelias/wof#52](https://github.com/pelias/wof/pull/52))
 - **Spain**: Using data from the Centro de Descargas, update administrative records in Spain including Ceuta and Melilla. Issue [#706](https://github.com/whosonfirst-data/whosonfirst-data/issues/706))
 - **United Kingdom**: Wrangle UK records, moving them from the `admin-xy` repository to the `admin-gb` repository. Issue [#2024](https://github.com/whosonfirst-data/whosonfirst-data/issues/2024))
-- **Various**: 21 [edits](https://github.com/pulls?q=is%3Apr+user%3Awhosonfirst-data+archived%3Afalse+merged%3A2023-09-01..2023-09-31+is%3Aclosed+) made directly to the individual country repos as PRs...
+- **Various**: 21 [edits](https://github.com/pulls?q=is%3Apr+user%3Awhosonfirst-data+archived%3Afalse+merged%3A2023-10-01..2023-10-31+is%3Aclosed+) made directly to the individual country repos as PRs...
 
 ### 2023 November
 
 - **United Kingdom**: Using United Kingdom and Northern Ireland Ordnance Survey data, update records and geometries at various placetypes. This includes updates to `localadmin`, `county`, `macrocounty`, `region`, `macroregion`, and `country` records. Additional work is contemplated at the `locality` level but not included here. Pull request [#92](https://github.com/whosonfirst-data/whosonfirst-data-admin-gb/pull/92))
+- **Various**: A quiet month
 
 ### 2023 Decemmber
 
-- **Various**: 15 [edits](https://github.com/pulls?q=is%3Apr+user%3Awhosonfirst-data+archived%3Afalse+merged%3A2023-09-01..2023-09-31+is%3Aclosed+) made directly to the individual country repos as PRs...
+- **Various**: 15 [edits](https://github.com/pulls?q=is%3Apr+user%3Awhosonfirst-data+archived%3Afalse+merged%3A2023-12-01..2023-12-31+is%3Aclosed+) made directly to the individual country repos as PRs...
 
 _NOTE: This document was created 2019 November._


### PR DESCRIPTION
This PR updates the `CHANGELOG.md` file to include July, August, and September 2023 updates.
Once in-progress PRs are merged (centroid updates, concordance, and label work), I'll append those changes, too.